### PR TITLE
Update 2.2.3

### DIFF
--- a/!Vendorer.toc
+++ b/!Vendorer.toc
@@ -2,7 +2,7 @@
 ## Title: Vendorer
 ## Notes: Miscellaneous vendor stuff
 ## Author: Sonaza
-## Version: 2.2.2
+## Version: 2.2.3
 ## OptionalDeps: Ace3
 ## SavedVariables: VendorerDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.2.3
 * Added some items with passive or otherwise useful bonuses to the default ignore list.
 * If using wide frame the merchant window will now automatically temporarily collapse to narrow width if vendor only has one page's worth of goods. 
+* Improved compability with other localization languages than English.
 
 ## 2.2.2
 * Made narrow frame the default again.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.3
 * Added some items with passive or otherwise useful bonuses to the default ignore list.
-* If using wide frame the merchant window will now automatically temporarily collapse to narrow width if vendor only has one page's worth of goods. 
+* If using the wide frame the merchant window will now automatically temporarily collapse to the narrow width if a vendor has only one page's worth of goods. 
 * Improved compability with other localization languages than English.
 
 ## 2.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.3
+* Added some items with passive or otherwise useful bonuses to the default ignore list.
+
 ## 2.2.2
 * Made narrow frame the default again.
 * Added notification about ability to switch frame width.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.2.3
 * Added some items with passive or otherwise useful bonuses to the default ignore list.
+* If using wide frame the merchant window will now automatically temporarily collapse to narrow width if vendor only has one page's worth of goods. 
 
 ## 2.2.2
 * Made narrow frame the default again.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Added some items with passive or otherwise useful bonuses to the default ignore list.
 * If using the wide frame the merchant window will now automatically temporarily collapse to the narrow width if a vendor has only one page's worth of goods. 
 * Improved compability with other localization languages than English.
+* Fixed error causing class armor highlight to be permanently enabled.
 
 ## 2.2.2
 * Made narrow frame the default again.

--- a/autorepair.lua
+++ b/autorepair.lua
@@ -1,6 +1,11 @@
-local ADDON_NAME, SHARED = ...;
+------------------------------------------------------------
+-- Vendorer by Sonaza
+-- All rights reserved
+-- http://sonaza.com
+------------------------------------------------------------
+
+local ADDON_NAME, Addon = ...;
 local _;
-local Addon = unpack(SHARED);
 
 function Addon:GetGuildAllowance(triggeredByUser)
 	if(not triggeredByUser and not Addon.db.global.SmartAutoRepair) then

--- a/core.lua
+++ b/core.lua
@@ -1,12 +1,15 @@
-local ADDON_NAME, SHARED = ...;
+------------------------------------------------------------
+-- Vendorer by Sonaza
+-- All rights reserved
+-- http://sonaza.com
+------------------------------------------------------------
 
-local _G = getfenv(0);
-
-local LibStub = LibStub;
-local Addon = LibStub("AceAddon-3.0"):NewAddon(ADDON_NAME, "AceEvent-3.0");
-local AceDB = LibStub("AceDB-3.0");
+local ADDON_NAME = ...;
+local Addon = LibStub("AceAddon-3.0"):NewAddon(select(2, ...), ADDON_NAME, "AceEvent-3.0");
 _G["Vendorer"] = Addon;
-SHARED[1] = Addon;
+
+local AceDB = LibStub("AceDB-3.0");
+local _;
 
 local LOCALIZED_CLOTH   = GetItemSubClassInfo(4, 1);
 local LOCALIZED_LEATHER = GetItemSubClassInfo(4, 2);

--- a/core.lua
+++ b/core.lua
@@ -1105,12 +1105,14 @@ hooksecurefunc("MerchantFrame_UpdateMerchantInfo", function()
 					rarityBorder:Show();
 				end
 				
-				if(isUsable and itemType == GetItemClassInfo(4) and Addon:IsArmorItemSlot(itemEquipLoc)) then
-					if(itemSubType ~= GetItemSubClassInfo(4, 5) and not Addon:IsValidClassArmorType(itemSubType)) then
-						SetItemButtonNameFrameVertexColor(merchantButton, 0.5, 0, 0);
-						SetItemButtonSlotVertexColor(merchantButton, 0.5, 0, 0);
-						SetItemButtonTextureVertexColor(itemButton, 0.5, 0, 0);
-						SetItemButtonNormalTextureVertexColor(itemButton, 0.5, 0, 0);
+				if(Addon.db.global.PaintArmorTypes) then
+					if(isUsable and itemType == GetItemClassInfo(4) and Addon:IsArmorItemSlot(itemEquipLoc)) then
+						if(itemSubType ~= GetItemSubClassInfo(4, 5) and not Addon:IsValidClassArmorType(itemSubType)) then
+							SetItemButtonNameFrameVertexColor(merchantButton, 0.5, 0, 0);
+							SetItemButtonSlotVertexColor(merchantButton, 0.5, 0, 0);
+							SetItemButtonTextureVertexColor(itemButton, 0.5, 0, 0);
+							SetItemButtonNormalTextureVertexColor(itemButton, 0.5, 0, 0);
+						end
 					end
 				end
 			end

--- a/core.lua
+++ b/core.lua
@@ -139,7 +139,21 @@ function Addon:OnInitialize()
 			AutoRepair = false,
 			SmartAutoRepair = true,
 			
-			ItemIgnoreList = {},
+			ItemIgnoreList = {
+				[33820]     = true, -- Weather-Beaten Fishing Hat
+				[2901]      = true, -- Mining Pick
+				[44731]     = true, -- Bouquet of Ebon Roses
+				[19970]     = true, -- Arcanite Fishing Pole
+				[116913]    = true, -- Peon's Mining Pick
+				[116916]    = true, -- Gorepetal's Gentle Grasp
+				[84661]     = true, -- Dragon Fishing Pole
+				[103678]    = true, -- Time-Lost Artifact
+				[86566]     = true, -- Forager's Gloves
+				[63207]     = true, -- Wrap of Unity
+				[63353]     = true, -- Shroud of Cooperation
+				[63206]     = true, -- Wrap of Unity
+				[65274]     = true, -- Cloak of Coordination
+			},
 			ItemJunkList = {},
 			
 			ExpandTutorialShown = false,

--- a/core.lua
+++ b/core.lua
@@ -13,6 +13,9 @@ local LOCALIZED_LEATHER = GetItemSubClassInfo(4, 2);
 local LOCALIZED_MAIL    = GetItemSubClassInfo(4, 3);
 local LOCALIZED_PLATE   = GetItemSubClassInfo(4, 4);
 
+local LOCALIZED_ARMOR    = GetItemClassInfo(4);
+local LOCALIZED_COSMETIC = GetItemSubClassInfo(4, 5);
+
 local CLASS_ARMOR_TYPES = {
 	WARRIOR     = LOCALIZED_PLATE,
 	PALADIN     = LOCALIZED_PLATE,
@@ -1106,8 +1109,8 @@ hooksecurefunc("MerchantFrame_UpdateMerchantInfo", function()
 				end
 				
 				if(Addon.db.global.PaintArmorTypes) then
-					if(isUsable and itemType == GetItemClassInfo(4) and Addon:IsArmorItemSlot(itemEquipLoc)) then
-						if(itemSubType ~= GetItemSubClassInfo(4, 5) and not Addon:IsValidClassArmorType(itemSubType)) then
+					if(isUsable and itemType == LOCALIZED_ARMOR and Addon:IsArmorItemSlot(itemEquipLoc)) then
+						if(itemSubType ~= LOCALIZED_COSMETIC and not Addon:IsValidClassArmorType(itemSubType)) then
 							SetItemButtonNameFrameVertexColor(merchantButton, 0.5, 0, 0);
 							SetItemButtonSlotVertexColor(merchantButton, 0.5, 0, 0);
 							SetItemButtonTextureVertexColor(itemButton, 0.5, 0, 0);

--- a/core.lua
+++ b/core.lua
@@ -79,6 +79,22 @@ local STAT_SLOTS = {
 	["INVTYPE_WRIST"]			= true,
 };
 
+local DEFAULT_IGNORE_LIST_ITEMS = {
+	[33820]     = true, -- Weather-Beaten Fishing Hat
+	[2901]      = true, -- Mining Pick
+	[44731]     = true, -- Bouquet of Ebon Roses
+	[19970]     = true, -- Arcanite Fishing Pole
+	[116913]    = true, -- Peon's Mining Pick
+	[116916]    = true, -- Gorepetal's Gentle Grasp
+	[84661]     = true, -- Dragon Fishing Pole
+	[103678]    = true, -- Time-Lost Artifact
+	[86566]     = true, -- Forager's Gloves
+	[63207]     = true, -- Wrap of Unity
+	[63353]     = true, -- Shroud of Cooperation
+	[63206]     = true, -- Wrap of Unity
+	[65274]     = true, -- Cloak of Coordination
+};
+
 StaticPopupDialogs["VENDORER_CONFIRM_SELL_UNUSABLES"] = {
 	text = "Are you sure you want to sell unusable items? You can still buyback them after.",
 	button1 = YES,
@@ -96,8 +112,8 @@ StaticPopupDialogs["VENDORER_CONFIRM_CLEAR_IGNORE_LIST"] = {
 	button1 = YES,
 	button2 = NO,
 	OnAccept = function(self)
-		Addon.db.global.ItemIgnoreList = {};
-		Addon:AddMessage("Ignore list wiped.");
+		Addon.db.global.ItemIgnoreList = DEFAULT_IGNORE_LIST_ITEMS;
+		Addon:AddMessage("Ignore list wiped (restored to defaults).");
 	end,
 	timeout = 0,
 	whileDead = 1,
@@ -150,21 +166,7 @@ function Addon:OnInitialize()
 			AutoRepair = false,
 			SmartAutoRepair = true,
 			
-			ItemIgnoreList = {
-				[33820]     = true, -- Weather-Beaten Fishing Hat
-				[2901]      = true, -- Mining Pick
-				[44731]     = true, -- Bouquet of Ebon Roses
-				[19970]     = true, -- Arcanite Fishing Pole
-				[116913]    = true, -- Peon's Mining Pick
-				[116916]    = true, -- Gorepetal's Gentle Grasp
-				[84661]     = true, -- Dragon Fishing Pole
-				[103678]    = true, -- Time-Lost Artifact
-				[86566]     = true, -- Forager's Gloves
-				[63207]     = true, -- Wrap of Unity
-				[63353]     = true, -- Shroud of Cooperation
-				[63206]     = true, -- Wrap of Unity
-				[65274]     = true, -- Cloak of Coordination
-			},
+			ItemIgnoreList = DEFAULT_IGNORE_LIST_ITEMS,
 			ItemJunkList = {},
 			
 			ExpandTutorialShown = false,

--- a/core.lua
+++ b/core.lua
@@ -263,8 +263,21 @@ function Addon:UpdateExtensionPanel()
 	end
 end
 
+function Addon:GetCurrentExtension()
+	local extension = Addon.db.global.MerchantFrameExtension;
+	local numItems = Addon:GetUnfilteredMerchantNumItems();
+	
+	if(numItems <= 10 and extension == VENDORER_EXTENSION_WIDE) then
+		extension = VENDORER_EXTENSION_NARROW;
+	end
+	
+	return extension;
+end
+
 function Addon:ShowExtensionPanel()
-	if(Addon.db.global.MerchantFrameExtension == VENDORER_EXTENSION_WIDE) then
+	local extension = Addon:GetCurrentExtension();
+	
+	if(extension == VENDORER_EXTENSION_WIDE) then
 		MerchantFrame:SetWidth(834);
 		MERCHANT_ITEMS_PER_PAGE = 20;
 		
@@ -273,7 +286,7 @@ function Addon:ShowExtensionPanel()
 		VendorerMerchantFrameExtension:Show();
 		VendorerMerchantFrameExtensionNarrow:Hide();
 		VendorerMerchantFrameExtensionWide:Show();
-	else
+	elseif(extension == VENDORER_EXTENSION_NARROW) then
 		MerchantFrame:SetWidth(500);
 		MERCHANT_ITEMS_PER_PAGE = 10;
 	
@@ -1035,7 +1048,8 @@ function Addon:MERCHANT_CLOSED()
 end
 
 hooksecurefunc("MerchantFrame_UpdateMerchantInfo", function()
-	if(Addon.db.global.MerchantFrameExtension == VENDORER_EXTENSION_WIDE) then
+	local extension = Addon:GetCurrentExtension();
+	if(extension == VENDORER_EXTENSION_WIDE) then
 		MerchantItem11:ClearAllPoints();
 		MerchantItem11:SetPoint("TOPLEFT", MerchantItem2, "TOPRIGHT", 12, 0);
 		MerchantItem11:Show();
@@ -1087,7 +1101,7 @@ hooksecurefunc("MerchantFrame_UpdateMerchantInfo", function()
 				end
 				
 				if(isUsable and itemType == "Armor" and Addon:IsArmorItemSlot(itemEquipLoc)) then
-					if(itemSubType ~="Cosmetic" and not Addon:IsValidClassArmorType(itemSubType)) then
+					if(itemSubType ~= "Cosmetic" and not Addon:IsValidClassArmorType(itemSubType)) then
 						SetItemButtonNameFrameVertexColor(merchantButton, 0.5, 0, 0);
 						SetItemButtonSlotVertexColor(merchantButton, 0.5, 0, 0);
 						SetItemButtonTextureVertexColor(itemButton, 0.5, 0, 0);

--- a/core.lua
+++ b/core.lua
@@ -8,26 +8,31 @@ local AceDB = LibStub("AceDB-3.0");
 _G["Vendorer"] = Addon;
 SHARED[1] = Addon;
 
+local LOCALIZED_CLOTH   = GetItemSubClassInfo(4, 1);
+local LOCALIZED_LEATHER = GetItemSubClassInfo(4, 2);
+local LOCALIZED_MAIL    = GetItemSubClassInfo(4, 3);
+local LOCALIZED_PLATE   = GetItemSubClassInfo(4, 4);
+
 local CLASS_ARMOR_TYPES = {
-	WARRIOR     = "Plate",
-	PALADIN     = "Plate",
-	DEATHKNIGHT = "Plate",
-	HUNTER      = "Mail",
-	SHAMAN      = "Mail",
-	MONK        = "Leather",
-	DRUID       = "Leather",
-	ROGUE       = "Leather",
-	DEMONHUNTER = "Leather",
-	MAGE        = "Cloth",
-	WARLOCK     = "Cloth",
-	PRIEST      = "Cloth",
+	WARRIOR     = LOCALIZED_PLATE,
+	PALADIN     = LOCALIZED_PLATE,
+	DEATHKNIGHT = LOCALIZED_PLATE,
+	HUNTER      = LOCALIZED_MAIL,
+	SHAMAN      = LOCALIZED_MAIL,
+	MONK        = LOCALIZED_LEATHER,
+	DRUID       = LOCALIZED_LEATHER,
+	ROGUE       = LOCALIZED_LEATHER,
+	DEMONHUNTER = LOCALIZED_LEATHER,
+	MAGE        = LOCALIZED_PLATE,
+	WARLOCK     = LOCALIZED_PLATE,
+	PRIEST      = LOCALIZED_PLATE,
 };
 
 local ARMOR_TYPE_LEVEL = {
-	["Cloth"]	= 1,
-	["Leather"]	= 2,
-	["Mail"]	= 3,
-	["Plate"]	= 4,
+	[LOCALIZED_CLOTH]   = 1,
+	[LOCALIZED_LEATHER] = 2,
+	[LOCALIZED_MAIL]    = 3,
+	[LOCALIZED_PLATE]   = 4,
 };
 
 local ARMOR_SLOTS = {
@@ -1100,8 +1105,8 @@ hooksecurefunc("MerchantFrame_UpdateMerchantInfo", function()
 					rarityBorder:Show();
 				end
 				
-				if(isUsable and itemType == "Armor" and Addon:IsArmorItemSlot(itemEquipLoc)) then
-					if(itemSubType ~= "Cosmetic" and not Addon:IsValidClassArmorType(itemSubType)) then
+				if(isUsable and itemType == GetItemClassInfo(4) and Addon:IsArmorItemSlot(itemEquipLoc)) then
+					if(itemSubType ~= GetItemSubClassInfo(4, 5) and not Addon:IsValidClassArmorType(itemSubType)) then
 						SetItemButtonNameFrameVertexColor(merchantButton, 0.5, 0, 0);
 						SetItemButtonSlotVertexColor(merchantButton, 0.5, 0, 0);
 						SetItemButtonTextureVertexColor(itemButton, 0.5, 0, 0);

--- a/vendorfilter.lua
+++ b/vendorfilter.lua
@@ -287,10 +287,14 @@ function Addon:FilterItem(index)
 	return filter;
 end
 
+function Addon:GetUnfilteredMerchantNumItems()
+	return _GetMerchantNumItems();
+end
+
 function Addon:RefreshFilteredItems()
 	FilteredMerchantItems = {};
 	
-	local merchantItems = _GetMerchantNumItems();
+	local merchantItems = Addon:GetUnfilteredMerchantNumItems();
 	for index = 1, merchantItems do 
 		if(Addon.FilterText == "" or Addon:FilterItem(index)) then
 			tinsert(FilteredMerchantItems, index);

--- a/vendorfilter.lua
+++ b/vendorfilter.lua
@@ -1,6 +1,11 @@
-local ADDON_NAME, SHARED = ...;
+------------------------------------------------------------
+-- Vendorer by Sonaza
+-- All rights reserved
+-- http://sonaza.com
+------------------------------------------------------------
+
+local ADDON_NAME, Addon = ...;
 local _;
-local Addon = unpack(SHARED);
 
 local FilteredMerchantItems = nil;
 

--- a/vendorfilter.lua
+++ b/vendorfilter.lua
@@ -23,8 +23,6 @@ local _GameTooltip_SetMerchantItem = GameTooltip.SetMerchantItem;
 local _GameTooltip_SetMerchantCostItem = GameTooltip.SetMerchantCostItem;
 
 GameTooltip.SetMerchantItem = function(self, index)
-	-- print("GameTooltip.SetMerchantItem", index)
-	
 	if(not index) then return end
 	
 	if(FilteredMerchantItems[index]) then
@@ -84,8 +82,6 @@ _G.GetMerchantItemCostItem = function(index, itemIndex)
 end
 
 _G.GetMerchantItemInfo = function(index)
-	-- index)
-	
 	if(not index) then return end
 	
 	if(not FilteredMerchantItems[index]) then Addon:RefreshFilteredItems(); end
@@ -241,8 +237,6 @@ function Addon:FilterItem(index)
 					result = comparison.func(itemMinLevel, value);
 					
 				elseif(comparison.type == VALUE_TYPE_ILVL and value) then
-					-- print(token, comparison.pattern, itemLevel, value);
-					
 					matchFound = true;
 					result = comparison.func(itemLevel, value);
 					
@@ -273,10 +267,7 @@ function Addon:FilterItem(index)
 				for costItemIndex = 1, numCostItems do
 					local _, costItemValue, costItemLink, currencyName = _GetMerchantItemCostItem(index, costItemIndex);
 					if(costItemLink) then
-						-- local itemName = strmatch(costItemLink, "%[(.+)%]");
-						-- if(itemName) then
-							result = result or strfind(string.lower(costItemLink), token) ~= nil;
-						-- end
+						result = result or strfind(string.lower(costItemLink), token) ~= nil;
 					elseif(currencyName) then
 						result = result or strfind(string.lower(currencyName), token) ~= nil;
 					end

--- a/vendorfilter.lua
+++ b/vendorfilter.lua
@@ -354,7 +354,7 @@ end);
 
 hooksecurefunc("MerchantFrame_UpdateMerchantInfo", function()
 	local numMerchantItems = GetMerchantNumItems();
-	local realNumMerchantItems = _GetMerchantNumItems();
+	local realNumMerchantItems = Addon:GetUnfilteredMerchantNumItems();
 	local maxPages = math.ceil(numMerchantItems / MERCHANT_ITEMS_PER_PAGE);
 	
 	if(maxPages <= 1) then


### PR DESCRIPTION
- Added some items with passive or otherwise useful bonuses to the default ignore list.
- If using the wide frame the merchant window will now automatically temporarily collapse to the narrow width if a vendor has only one page's worth of goods. 
- Improved compability with other localization languages than English.
- Fixed error causing class armor highlight to be permanently enabled.
